### PR TITLE
Add docker-compose support.

### DIFF
--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -1,0 +1,33 @@
+FROM python:buster
+
+RUN apt-get update && apt-get install -y \
+    apache2 \
+    autoconf \
+    autotools-dev \
+    build-essential \
+    curl \
+    cmake \
+    git \
+    libapache2-mod-wsgi-py3 \
+    default-libmysqlclient-dev \
+    libssl-dev \
+    default-mysql-client
+
+COPY . /srv/encore
+
+RUN mkdir /srv/encore/build
+
+WORKDIR /srv/encore/build
+
+RUN cmake -DCMAKE_BUILD_TYPE=Release .. \
+ && make
+
+WORKDIR /srv/encore
+
+RUN pip install -r requirements.txt \
+ && ln -s /srv/encore/encore.conf.example /etc/apache2/sites-enabled/encore.conf
+
+EXPOSE 80/tcp
+EXPOSE 443/tcp
+
+CMD [ "/bin/bash", "-c", "rm -f /var/run/apache2/* && apache2ctl -D FOREGROUND" ]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,32 @@
+version: '3.3'
+services:
+  db:
+    image: mariadb:10
+    volumes:
+      - db_data:/var/lib/mysql
+      - ./schema.sql:/docker-entrypoint-initdb.d/schema.sql
+    environment:
+      MYSQL_ROOT_PASSWORD: my_pwd
+      MYSQL_USER: my_user
+      MYSQL_PASSWORD: my_pwd
+      MYSQL_DATABASE: my_db 
+  encore:
+    build:
+      context: .
+      dockerfile: Dockerfile.prod
+    environment:
+      MYSQL_HOST: db
+      MYSQL_DB: my_db
+      MYSQL_USER: my_user
+      MYSQL_PASSWORD: my_pwd
+      SERVER_NAME: localhost
+#      GOOGLE_LOGIN_CLIENT_ID:
+#      GOOGLE_LOGIN_CLIENT_SECRET:
+    ports:
+      - 80:80
+    volumes:
+      - ./encore.conf.dev:/etc/apache2/sites-enabled/encore.conf
+      - ./flask_config.py.example:/srv/encore/flask_config.py
+      - ./encore.wsgi.example:/srv/encore/encore.wsgi
+volumes:
+  db_data: {}

--- a/encore.conf.dev
+++ b/encore.conf.dev
@@ -1,0 +1,29 @@
+<VirtualHost *:80>
+    ServerAdmin webmaster@localhost
+    DocumentRoot "/srv/encore/encore"
+    ServerName localhost
+    ErrorLog "/proc/self/fd/2"
+    CustomLog "/proc/self/fd/1" common
+
+    #Removes stack underflow error
+    WSGIApplicationGroup %{GLOBAL}
+
+    WSGIDaemonProcess localhost processes=1 threads=1 home=/srv/encore
+    WSGIProcessGroup localhost
+    WSGIScriptAlias / /srv/encore/encore.wsgi
+	WSGIPassAuthorization On
+
+   <Location /server-info>
+      SetHandler server-info
+      Order deny,allow
+      Deny from all
+    </Location>
+
+    <Directory /srv/encore>
+        Require all granted
+    </Directory>
+
+    <Files /srv/encore/encore.wsgi>
+        Require all granted
+    </Files>
+</VirtualHost>

--- a/encore.wsgi.example
+++ b/encore.wsgi.example
@@ -1,7 +1,9 @@
-#replace encore-path with path to repo folder
+#! /usr/bin/python3
+# Uncomment and replace encore-path with path to repo folder
 import os, sys
 
-PROJECT_DIR = 'encore-path'
+PROJECT_DIR = os.path.dirname(os.path.abspath(__file__))
+# PROJECT_DIR = 'encore-path'
 
 def activate_venv(__file__):
 	old_os_path = os.environ.get('PATH', '')

--- a/encore/db_helpers.py
+++ b/encore/db_helpers.py
@@ -216,7 +216,7 @@ class SelectQuery:
         return page, order_by, qfilter
 
 
-PageInfo = namedtuple('PageInfo', ['limit', 'offset'], verbose=False)
+PageInfo = namedtuple('PageInfo', ['limit', 'offset'])
 
 class PagedResult:
     def __init__(self, results=[], total_count=0, filtered_count=0, page=None):

--- a/encore/sql_pool.py
+++ b/encore/sql_pool.py
@@ -13,7 +13,8 @@ def register_db(app):
 def get_conn():
     con = getattr(g, '_database_con', None)
     if con is None:
-        con = g._database_con = MySQLdb.connect(host="localhost", 
+        con = g._database_con = MySQLdb.connect(
+        host=current_app.config.get("MYSQL_HOST"), 
         user=current_app.config.get("MYSQL_USER"), 
         passwd=current_app.config.get("MYSQL_PASSWORD"), 
         db=current_app.config.get("MYSQL_DB"))

--- a/flask_config.py.example
+++ b/flask_config.py.example
@@ -1,37 +1,40 @@
-SERVER_NAME = "encore.sph.umich.edu"
+#!/usr/bin/env python3
 
-JOB_DATA_FOLDER = "./"
-PHENO_DATA_FOLDER = "./"
-GENO_DATA_FOLDER = "./"
-EPACTS_BINARY = "epacts"
-QUEUE_JOB_BINARY = "sbatch"
-MANHATTAN_BINARY = "make_manhattan_json.py"
-QQPLOT_BINARY = "make_qq_json.py"
-TOPHITS_BINARY = "make_tophits_json.py"
-NEAREST_GENE_BED = "data/nearest-gene.bed"
-
-VCF_FILE = ""
-
-MYSQL_DB = "my_db"
-MYSQL_USER = "my_user"
-MYSQL_PASSWORD = "my_pass"
-
-BUILD_REF = {
-    "GRCh37": {
-        "fasta": "/data/ref/hs37d5.fa",
-        "nearest_gene_bed": "/data/ref/nearest-gene.GRCh37.bed"
-    },
-    "GRCh38": {
-        "fasta": "/data/ref/hs38DH.fa",
-        "nearest_gene_bed": "/data/ref/nearest-gene.GRCh38.bed"
+import os
+DEFAULT_CONFIG = {
+    'SERVER_NAME': 'encore.sph.umich.edu',
+    'JOB_DATA_FOLDER': './',
+    'PHENO_DATA_FOLDER': './',
+    'GENO_DATA_FOLDER': './',
+    'EPACTS_BINARY': 'epacts',
+    'QUEUE_JOB_BINARY': 'sbatch',
+    'MANHATTAN_BINARY': 'make_manhattan_json.py',
+    'QQPLOT_BINARY': 'make_qq_json.py',
+    'TOPHITS_BINARY': 'make_tophits_json.py',
+    'NEAREST_GENE_BED': 'data/nearest-gene.bed',
+    'VCF_FILE': '',
+    'MYSQL_HOST': 'localhost',
+    'MYSQL_DB': 'my_db',
+    'MYSQL_USER': 'my_user',
+    'MYSQL_PASSWORD': 'my_pwd',
+    'SECRET_KEY': None,
+    'JWT_SECRET_KEY': None,
+    'GOOGLE_LOGIN_CLIENT_ID': None,
+    'GOOGLE_LOGIN_CLIENT_SECRET': None,
+    'HELP_EMAIL': '',
+    'BUILD_REF': {
+        'GRCh37': {
+            'fasta': '/data/ref/hs37d5.fa',
+            'nearest_gene_bed': '/data/ref/nearest-gene.GRCh37.bed'
+        },
+        'GRCh38': {
+            'fasta': '/data/ref/hs38DH.fa',
+            'nearest_gene_bed': '/data/ref/nearest-gene.GRCh38.bed'
+        }
     }
 }
 
-
-SECRET_KEY = None
-JWT_SECRET_KEY = None
-
-GOOGLE_LOGIN_CLIENT_ID = None
-GOOGLE_LOGIN_CLIENT_SECRET = None
-
-HELP_EMAIL = ""
+for key in DEFAULT_CONFIG.keys():
+    if os.getenv(key):
+        DEFAULT_CONFIG[key] = os.environ[key]
+    globals()[key] = DEFAULT_CONFIG[key]


### PR DESCRIPTION
This PR does a few things:
- Removes the remaining verbose parameter on namedtuple objects for python 3.7 support
- Updates the `flask_config.example` to take parameters from environment variables if they are present.
- Adds support for remote databases.
- Adds a new container (Dockerfile.prod) that removes mysql and is built off `python:buster`
- Adds a "dev" version of the encore.conf example  that uses localhost.
- Adds a docker-compose file to spin up the database and new container.