### PR TITLE
Update container image, compose and flask defaults

### DIFF
--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -1,4 +1,4 @@
-FROM python:buster
+FROM python:3.7-buster
 
 RUN apt-get update && apt-get install -y \
     apache2 \

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -9,14 +9,14 @@ services:
       MYSQL_ROOT_PASSWORD: my_pwd
       MYSQL_USER: my_user
       MYSQL_PASSWORD: my_pwd
-      MYSQL_DATABASE: my_db 
+      MYSQL_DATABASE: encore
   encore:
     build:
       context: .
       dockerfile: Dockerfile.prod
     environment:
       MYSQL_HOST: db
-      MYSQL_DB: my_db
+      MYSQL_DB: encore
       MYSQL_USER: my_user
       MYSQL_PASSWORD: my_pwd
       SERVER_NAME: localhost

--- a/flask_config.py.example
+++ b/flask_config.py.example
@@ -17,7 +17,7 @@ DEFAULT_CONFIG = {
     'MYSQL_DB': 'my_db',
     'MYSQL_USER': 'my_user',
     'MYSQL_PASSWORD': 'my_pwd',
-    'SECRET_KEY': None,
+    'SECRET_KEY': os.urandom(24),
     'JWT_SECRET_KEY': None,
     'GOOGLE_LOGIN_CLIENT_ID': None,
     'GOOGLE_LOGIN_CLIENT_SECRET': None,


### PR DESCRIPTION
- Pins container image to python 3.7. scipy is not currently supported under python 3.8.
- Updates the default database name in docker-compose to match the created db from schema.sql
- Defaults SECRET_KEY to use a randomly generated value.